### PR TITLE
Added support for .NET Framework 4.5

### DIFF
--- a/src/NLog.Gelf/GelfHttpTarget.cs
+++ b/src/NLog.Gelf/GelfHttpTarget.cs
@@ -139,9 +139,9 @@ namespace NLog.Gelf
 
         private static readonly Dictionary<string, SyslogSeverity> LogLevelMap = new Dictionary<string, SyslogSeverity>
         {
-            {LogLevel.Trace.Name, SyslogSeverity.Informational},
+            {LogLevel.Trace.Name, SyslogSeverity.Debug},
             {LogLevel.Debug.Name, SyslogSeverity.Debug},
-            {LogLevel.Info.Name, SyslogSeverity.Notice},
+            {LogLevel.Info.Name, SyslogSeverity.Informational},
             {LogLevel.Warn.Name, SyslogSeverity.Warning},
             {LogLevel.Error.Name, SyslogSeverity.Error},
             {LogLevel.Fatal.Name, SyslogSeverity.Alert}
@@ -154,7 +154,7 @@ namespace NLog.Gelf
             if (LogLevelMap.TryGetValue(level.Name, out severity))
                 return severity;
 
-            return SyslogSeverity.Informational;
+            return SyslogSeverity.Debug;
         }
     }
 }

--- a/src/NLog.Gelf/GelfHttpTarget.cs
+++ b/src/NLog.Gelf/GelfHttpTarget.cs
@@ -59,7 +59,7 @@ namespace NLog.Gelf
             catch (Exception ex)
             {
                 InternalLogger.Log(ex, LogLevel.Error, "Unable to send logging event to remote host " + ServerUrl);
-                Sender.Send(CreateFatalGelfJson(ex));
+                //Sender.Send(CreateFatalGelfJson(ex));
             }
         }
 
@@ -108,7 +108,7 @@ namespace NLog.Gelf
             return gelfMessage;
         }
 
-        private GelfMessage CreateFatalGelfJson(Exception exception)
+        /*private GelfMessage CreateFatalGelfJson(Exception exception)
         {
             var gelfMessage = new GelfMessage
             {
@@ -135,7 +135,7 @@ namespace NLog.Gelf
             }
 
             return gelfMessage;
-        }
+        }*/
 
         private static readonly Dictionary<string, SyslogSeverity> LogLevelMap = new Dictionary<string, SyslogSeverity>
         {

--- a/src/NLog.Gelf/NLog.Gelf.csproj
+++ b/src/NLog.Gelf/NLog.Gelf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <PackageProjectUrl>https://github.com/mantasaudickas/NLog.Gelf</PackageProjectUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <AssemblyVersion>1.1.0.1</AssemblyVersion>
@@ -11,9 +11,15 @@
     <Description>Http Gelf sender for NLog</Description>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-beta4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net45'">
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+    <PackageReference Include="NLog" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Added support for .NET Framework 4.5
- Fixed mapping from NLog severity to SysLog, to map NLog.Trace and NLog.Debug to SysLog.Debug
- Removed Sender.Send from catch block because it could case application crash if Sender fails