### PR TITLE
Added support for .NET Standard 2.0

### DIFF
--- a/src/NLog.Gelf/NLog.Gelf.csproj
+++ b/src/NLog.Gelf/NLog.Gelf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45;netstandard2.0</TargetFrameworks>
     <PackageProjectUrl>https://github.com/mantasaudickas/NLog.Gelf</PackageProjectUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <AssemblyVersion>1.1.3</AssemblyVersion>
@@ -14,7 +14,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
-  
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-rc4" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-beta5" />
   </ItemGroup>


### PR DESCRIPTION
For .NET Standard 2.0 NLog.Extensions.Logging has dependency on a different version of NLog rather than in 1.3. So I just added another target with the latest dependency version. No changes in the code itself.